### PR TITLE
Fix from issue XMLBEANS-404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/.settings/
+/.classpath
+/.project

--- a/src/store/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/store/org/apache/xmlbeans/impl/store/Saver.java
@@ -1403,7 +1403,7 @@ abstract class Saver
                 if (++i == _buf.length)
                     i = 0;
 
-                for ( int cch = _lastEmitCch ; cch > 0 ; cch-- )
+                for ( int cch = _lastEmitCch - 2 ; cch > 0 ; cch-- )
                 {
                     char ch = _buf[ i ];
 


### PR DESCRIPTION
I encountered this bug in a client file.  Making this change as noted in the issue comments for [XMLBEANS-404](https://issues.apache.org/jira/browse/XMLBEANS-404) fixed it for me.  

I don't need the gitignore change, but if you accept that one too, forks can have local Eclipse configurations that aren't accidentally included in pull requests. 